### PR TITLE
binary is now helm-s3 not helms3 in tar

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,7 +37,7 @@ install() {
 
 	pushd "${bin_install_path}" >/dev/null
 
-	curl -sL "${download_url}" | tar zx -O bin/helms3 >"${bin_install_path}/helm-s3"
+	curl -sL "${download_url}" | tar zx -O bin/helm-s3 >"${bin_install_path}/helm-s3"
 
 	chmod +x "${bin_install_path}/helm-s3"
 


### PR DESCRIPTION
binary is helm-s3 now in tar not helms3 :)

Tested : 

```
343fe98b9816:/$ asdf plugin-add helm-s3 https://github.com/noony/asdf-helm-s3
343fe98b9816:/$ asdf install helm-s3 0.16.2
Downloading helm-s3 from https://github.com/hypnoglow/helm-s3/releases/download/v0.16.2/helm-s3_0.16.2_linux_amd64.tar.gz
Installed plugin: s3
```